### PR TITLE
Added characterEncoding in Javascript output

### DIFF
--- a/src/main/java/com/papercut/silken/SilkenServlet.java
+++ b/src/main/java/com/papercut/silken/SilkenServlet.java
@@ -268,6 +268,7 @@ public class SilkenServlet extends HttpServlet {
 
                 resp.setContentType(JS_CONTENT_TYPE);
                 resp.setHeader("Cache-Control", "max-age=" + Long.toString(config.getJavaScriptCacheMaxAge()));
+                resp.setCharacterEncoding("UTF-8");
                 resp.getWriter().print(templateRenderer.provideAsJavaScript(namespace, locale));
                 return;
             }


### PR DESCRIPTION
Soy's output encoding is UTF-8. So non Ascii characters are garbled.

When I tried to add setCharacterEncoding("UTF-8"), that worked well.
