### PR TITLE
Fix NullPointerException when retrieving resource paths

### DIFF
--- a/src/main/java/com/papercut/silken/WebAppFileSetResolver.java
+++ b/src/main/java/com/papercut/silken/WebAppFileSetResolver.java
@@ -93,12 +93,14 @@ public class WebAppFileSetResolver implements FileSetResolver {
         Set<String> files = (Set<String>) servletContext.getResourcePaths(path.toString());
 
         List<URL> resourceList = new ArrayList<URL>();
-        for (String file : files) {
-            if (file.endsWith(suffix)) {
-                try {
-                    resourceList.add(servletContext.getResource(file));
-                } catch (MalformedURLException e) {
-                    throw new RuntimeException("Unable to resolve resource at: " + file, e);
+        if (files != null) {
+            for (String file : files) {
+                if (file.endsWith(suffix)) {
+                    try {
+                        resourceList.add(servletContext.getResource(file));
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException("Unable to resolve resource at: " + file, e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixing NPE when retrieving resource paths in the case where your project doesn't contain a scanned path (e.g. /templates/shared, /WEB-INF/templates/shared, or some namespace you've created). Furthermore, it seems that the resolver scans both /WEB-INF/templates/{namespace} and /templates/{namespace}. If BOTH directories don't exist for your namespace, an NPE is thrown. Maybe a servlet api difference (considering I doubt you simply overlooked this)?
