### PR TITLE
Fixing incorrect year on maven version

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Artifact:
 ```
 <groupId>com.papercut.silken</groupId>
 <artifactId>silken</artifactId>
-<version>2012-03-05</version>
+<version>2013-03-05</version>
 ```
 
 


### PR DESCRIPTION
Minor documentation fix. Year should be 2013, not 2012
